### PR TITLE
Config mount program

### DIFF
--- a/scripts/parallax-mount-program.sh
+++ b/scripts/parallax-mount-program.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: --storage-opt mount_program=/path/to/parallax-mount-program.sh
 #

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -126,6 +126,5 @@ EOF
      echo "=== MOUNT-PROG STDOUT/ERR ==="
      echo "$output"
      echo "============================="
-     return 1
    }
 }

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# tests for parallax-mount-program.sh configuration and functional behavior
+
+setup() {
+  # Create working dirs and bins
+  TEST_DIR="$(mktemp -d)"
+  export PARALLAX_MP_LOGFILE="$TEST_DIR/mp.log"
+  export PARALLAX_MP_LOGLEVEL="DEBUG"
+  export PATH="$TEST_DIR/bin:$PATH"
+
+  mkdir -p "$TEST_DIR/bin"
+
+  # Create dummy lower, upper, work, and mountpoint dirs
+  LOWERDIR="$TEST_DIR/lowerdir"
+  UPPERRDIR="$TEST_DIR/upperdir"
+  WORKDIR="$TEST_DIR/workdir"
+  MNTPOINT="$TEST_DIR/mnt"
+  mkdir -p "$LOWERDIR" "$UPPERRDIR" "$WORKDIR" "$MNTPOINT"
+
+  # Copy mount program into test directory
+  cp "$PWD/scripts/parallax-mount-program.sh" "$TEST_DIR/"
+  chmod +x "$TEST_DIR/parallax-mount-program.sh"
+}
+
+teardown() {
+  umount "$MNTPOINT" >/dev/null 2>&1 || true
+  sleep 5
+  rm -rf "$TEST_DIR"
+}
+
+@test "Config file overrides for mount program tools setup" {
+  # Prepare a real but dummy squash image for lowerdir
+  mkdir -p "$LOWERDIR/content"
+  echo "hello" > "$LOWERDIR/content/file.txt"
+  mksquashfs "$LOWERDIR/content" "${LOWERDIR}.squash" -noappend -no-progress >/dev/null
+
+  # Test config file to override commands
+  cat <<EOF > "$TEST_DIR/parallax-mount.conf"
+PARALLAX_MP_SQUASHFUSE_CMD="echo custom-squashfuse"
+PARALLAX_MP_FUSE_OVERLAYFS_CMD="echo custom-fuse-overlayfs"
+EOF
+
+  # Run mount program using config
+  run env PARALLAX_MP_CONFIG="$TEST_DIR/parallax-mount.conf" \
+      "$TEST_DIR/parallax-mount-program.sh" \
+      --lowerdir="$LOWERDIR" --upperdir="$UPPERRDIR" \
+      --workdir="$WORKDIR" "$MNTPOINT"
+
+  # We should expect to see the custom commands in output
+  [[ "$output" =~ custom-squashfuse ]]
+  [[ "$output" =~ custom-fuse-overlayfs ]]
+}
+
+@test "ENV vars override defaults when no config file is passed" {
+  # Prepare a real but dummy squash image for lowerdir
+  mkdir -p "$LOWERDIR/content"
+  echo "world" > "$LOWERDIR/content/file2.txt"
+  mksquashfs "$LOWERDIR/content" "${LOWERDIR}.squash" -noappend -no-progress >/dev/null
+
+  # Unset any config
+  rm -f "$TEST_DIR/parallax-mount.conf"
+
+  # Override commands via ENV VARs
+  export PARALLAX_MP_SQUASHFUSE_CMD="echo env-squashfuse"
+  export PARALLAX_MP_FUSE_OVERLAYFS_CMD="echo env-fuse-overlayfs"
+
+  # Run mount program
+  run "$TEST_DIR/parallax-mount-program.sh" \
+      --lowerdir="$LOWERDIR" --upperdir="$UPPERRDIR" \
+      --workdir="$WORKDIR" "$MNTPOINT"
+
+  # Check env override
+  [[ "$output" =~ env-squashfuse ]]
+  [[ "$output" =~ env-fuse-overlayfs ]]
+}
+
+@test "watcher unmounts on deletion of etc directory" {
+  # Skip if we don't have real fuse binaries
+  command -v squashfuse >/dev/null || skip "needs squashfuse"
+  command -v fuse-overlayfs >/dev/null || skip "needs fuse-overlayfs"
+
+  # Build a real squashfs image containing an /etc directory
+  mkdir -p "$LOWERDIR/content/etc"
+  echo "keep me" > "$LOWERDIR/content/etc/important.conf"
+  mksquashfs "$LOWERDIR/content" "${LOWERDIR}.squash" -noappend -no-progress >/dev/null
+
+  # Launch the mount program in background
+  "$TEST_DIR/parallax-mount-program.sh" \
+    --lowerdir="$LOWERDIR" \
+    --upperdir="$UPPERRDIR" \
+    --workdir="$WORKDIR" \
+    "$MNTPOINT" &
+  pid=$!
+
+  # Give it a moment to finish mounting
+  sleep 3
+  run mountpoint -q "$MNTPOINT"
+  [ "$status" -eq 0 ]
+
+  # Now simulate container teardown by deleting the etc directory
+  rm -rf "$MNTPOINT/etc"
+
+  # Wait up to 5s for the watcher to catch the delete and exit
+  for i in $(seq 1 5); do
+    mountpoint -q "$MNTPOINT" && sleep 1 || break
+  done
+
+  # The mount program should exit cleanly once it sees the delete
+  wait $pid
+  [ "$?" -eq 0 ]
+
+  # And the overlay mount should be gone
+  ! mountpoint -q "$MNTPOINT"
+}
+

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -75,9 +75,10 @@ EOF
 }
 
 @test "watcher unmounts on deletion of etc directory" {
-  # Skip if we don't have real fuse binaries
+  # Skip if we don't have real binaries
   command -v squashfuse >/dev/null || skip "needs squashfuse"
   command -v fuse-overlayfs >/dev/null || skip "needs fuse-overlayfs"
+  command -v inotifywait >/dev/null || skip "needs inotifywait"
 
   # Build a real squashfs image containing an /etc directory
   mkdir -p "$LOWERDIR/content/etc"

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -122,5 +122,10 @@ EOF
       "$MNTPOINT"
 
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "missing-fuse-overlayfs not found" ]] || [[ "$output" =~ "command not found" ]]
+  [[ "$output" =~ "missing-fuse-overlayfs not found" ]] || [[ "$output" =~ "command not found" ]] || {
+     echo "=== MOUNT-PROG STDOUT/ERR ==="
+     echo "$output"
+     echo "============================="
+     return 1
+   }
 }

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -119,7 +119,7 @@ EOF
   echo '#!/usr/bin/env bash
   echo squashfuse
   ' > "$BINDIR/squashfuse"
-  chmod +x "$BINDIR/bin/squashfuse"
+  chmod +x "$BINDIR/squashfuse"
 
   run bash -x "$TEST_DIR/parallax-mount-program.sh" \
       "-o lowerdir=$LOWERDIR,upperdir=$UPPERRDIR,workdir=$WORKDIR" \

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -62,7 +62,7 @@ EOF
 
   # Run mount program using config
   run env PARALLAX_MP_CONFIG="$TEST_DIR/parallax-mount.conf" \
-      "$TEST_DIR/parallax-mount-program.sh" \
+      bash -x "$TEST_DIR/parallax-mount-program.sh" \
       --lowerdir="$LOWERDIR" --upperdir="$UPPERRDIR" \
       --workdir="$WORKDIR" "$MNTPOINT"
 
@@ -90,7 +90,7 @@ EOF
   export PARALLAX_MP_FUSE_OVERLAYFS_CMD="env-fuse-overlayfs"
 
   # Run mount program
-  run "$TEST_DIR/parallax-mount-program.sh" \
+  run bash -x "$TEST_DIR/parallax-mount-program.sh" \
       --lowerdir="$LOWERDIR" --upperdir="$UPPERRDIR" \
       --workdir="$WORKDIR" "$MNTPOINT"
 
@@ -111,7 +111,7 @@ EOF
   mksquashfs "$LOWERDIR/content" "${LOWERDIR}.squash" -noappend -no-progress >/dev/null
 
   # Launch the mount program in background
-  "$TEST_DIR/parallax-mount-program.sh" \
+  bash -x "$TEST_DIR/parallax-mount-program.sh" \
     --lowerdir="$LOWERDIR" \
     --upperdir="$UPPERRDIR" \
     --workdir="$WORKDIR" \

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -122,7 +122,7 @@ EOF
       "$MNTPOINT"
 
   [ "$status" -ne 0 ]
-  [[ "$output" =~ "missing-fuse-overlayfs not found" ]] || [[ "$output" =~ "command not found" ]] || {
+  [[ "$output" =~ "missing-fuse-overlayfs not found" ]] || {
      echo "=== MOUNT-PROG STDOUT/ERR ==="
      echo "$output"
      echo "============================="

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -105,17 +105,21 @@ EOF
   UPPERRDIR="$TEST_DIR/upperdir"
   WORKDIR="$TEST_DIR/workdir"
   MNTPOINT="$TEST_DIR/mnt"
-  mkdir -p "$LOWERDIR" "$UPPERRDIR" "$WORKDIR" "$MNTPOINT"
+  BINDIR="$TEST_DIR/bin"
+  mkdir -p "$LOWERDIR" "$UPPERRDIR" "$WORKDIR" "$MNTPOINT" "$BINDIR"
 
   # Remove config and unset vars
   rm -f "$TEST_DIR/parallax-mount.conf"
   unset PARALLAX_MP_SQUASHFUSE_CMD PARALLAX_MP_FUSE_OVERLAYFS_CMD
 
   # Restrict PATH so only stub squashfuse is found
-  export PATH="$TEST_DIR/bin"
+  export PATH="$BINDIR"
 
-  # Provide only squashfuse stub, omitting fuse-overlayfs
-  mv "$TEST_DIR/bin/env-squashfuse" "$TEST_DIR/bin/squashfuse"
+  # Provide only squashfuse stub, no fuse-overlayfs
+  echo '#!/usr/bin/env bash
+  echo squashfuse
+  ' > "$BINDIR/squashfuse"
+  chmod +x "$BINDIR/bin/squashfuse"
 
   run bash -x "$TEST_DIR/parallax-mount-program.sh" \
       "-o lowerdir=$LOWERDIR,upperdir=$UPPERRDIR,workdir=$WORKDIR" \
@@ -125,3 +129,4 @@ EOF
   [[ "$output" =~ "fuse-overlayfs not found" ]] || [[ "$output" =~ "command not found" ]]
   [[ ! "$output" =~ squashfuse-from-path ]]
 }
+

--- a/tests/mount-program-config.bats
+++ b/tests/mount-program-config.bats
@@ -62,9 +62,9 @@ EOF
 
   # Run mount program using config
   run env PARALLAX_MP_CONFIG="$TEST_DIR/parallax-mount.conf" \
-      bash -x "$TEST_DIR/parallax-mount-program.sh" \
-      --lowerdir="$LOWERDIR" --upperdir="$UPPERRDIR" \
-      --workdir="$WORKDIR" "$MNTPOINT"
+	  bash -x "$TEST_DIR/parallax-mount-program.sh" \
+      "lowerdir=$LOWERDIR,upperdir=$UPPERRDIR,workdir=$WORKDIR" \
+	  "$MNTPOINT"
 
   # We should expect to see the custom commands in output
   [[ "$output" =~ custom-squashfuse ]] || {
@@ -91,8 +91,8 @@ EOF
 
   # Run mount program
   run bash -x "$TEST_DIR/parallax-mount-program.sh" \
-      --lowerdir="$LOWERDIR" --upperdir="$UPPERRDIR" \
-      --workdir="$WORKDIR" "$MNTPOINT"
+      "lowerdir=$LOWERDIR,upperdir=$UPPERRDIR,workdir=$WORKDIR" \
+	  "$MNTPOINT"
 
   # Check env override
   [[ "$output" =~ env-squashfuse ]]
@@ -110,18 +110,20 @@ EOF
   echo "keep me" > "$LOWERDIR/content/etc/important.conf"
   mksquashfs "$LOWERDIR/content" "${LOWERDIR}.squash" -noappend -no-progress >/dev/null
 
+  export PARALLAX_MP_SQUASHFUSE_CMD="squashfuse"
+  export PARALLAX_MP_FUSE_OVERLAYFS_CMD="fuse-overlayfs"
+  export PARALLAX_MP_INOTIFYWAIT_CMD="inotifywait"
+
   # Launch the mount program in background
   bash -x "$TEST_DIR/parallax-mount-program.sh" \
-    --lowerdir="$LOWERDIR" \
-    --upperdir="$UPPERRDIR" \
-    --workdir="$WORKDIR" \
-    "$MNTPOINT" &
+      "lowerdir=$LOWERDIR,upperdir=$UPPERRDIR,workdir=$WORKDIR" \
+	  "$MNTPOINT"
   pid=$!
 
   # Give it a moment to finish mounting
   sleep 3
-  run mountpoint -q "$MNTPOINT"
-  [ "$status" -eq 0 ]
+  mountpoint -q "$MNTPOINT"
+  [ "$?" -eq 0 ]
 
   # Now simulate container teardown by deleting the etc directory
   rm -rf "$MNTPOINT/etc"


### PR DESCRIPTION
We add configuration capabilities for the mount program of parallax. Main feature contributed is that now we can configure the mount program via a system wide configuration file, or via environment variables. This push also adds testing of the configuration capability. Moreover, the changes dont break backward compatibility, so deployments without configurations continue to use whatever defaults are available in the system.