### PR TITLE
Rsync mirror

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -35,7 +35,7 @@ func RunMigration(cfg common.Config) (*storage.Image, error) {
 	if err != nil { return nil, err }
 	defer cleanupSrcStore()
 
-	scratchStore, cleanupScratch, err := setupScratchStore(cfg)
+	scratchStore, cleanupScratch, err := setupScratchStore(&cfg)
 	if err != nil { return nil, err }
 	defer cleanupScratch()
 

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -209,7 +209,7 @@ func setupSrcStore(cfg common.Config) (storage.Store, func(), error) {
 	return srcStore, cleanup, nil
 }
 
-func setupScratchStore(cfg common.Config) (storage.Store, func(), error) {
+func setupScratchStore(cfg *common.Config) (storage.Store, func(), error) {
 	sublog := log.WithField("fn", "setupScratchStore")
 
 	// we mirror the RoStoragePath to hide the fact that might be a networkedFS
@@ -316,6 +316,8 @@ func putFlattenedLayer(store storage.Store, dummyDir string, digest godigest.Dig
 }
 
 func readOverlayLink(layer *storage.Layer, cfg common.Config) (string, error) {
+	sublog := log.WithField("fn", "readOverlayLink")
+	sublog.Infof("Reading overlay link from %s", cfg.RoStoragePath)
 	linkBytes, err := os.ReadFile(filepath.Join(cfg.RoStoragePath, "overlay", layer.ID, "link"))
 	if err != nil {
 		return "", fmt.Errorf("read overlay link: %w", err)

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -218,7 +218,7 @@ func setupScratchStore(cfg common.Config) (storage.Store, func(), error) {
 		sublog.Debug("Failed to mount mirror: %v", err)
 		return nil, nil, err
 	}
-	sublog.Info("Mounted mirror of %q at %q", cfg.RoStoragePath, mirror)
+	sublog.Info("Mounted mirror of %s at %s", cfg.RoStoragePath, mirror)
 	originalPath := cfg.RoStoragePath
 	cfg.RoStoragePath = mirror
 

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -218,7 +218,7 @@ func setupScratchStore(cfg common.Config) (storage.Store, func(), error) {
 		sublog.Debug("Failed to mount mirror: %v", err)
 		return nil, nil, err
 	}
-	sublog.Info("Mounted mirror of %s at %s", cfg.RoStoragePath, mirror)
+	sublog.Infof("Mounted mirror of %s at %s", cfg.RoStoragePath, mirror)
 	originalPath := cfg.RoStoragePath
 	cfg.RoStoragePath = mirror
 

--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -219,11 +219,13 @@ func setupScratchStore(cfg common.Config) (storage.Store, func(), error) {
 		return nil, nil, err
 	}
 	sublog.Info("Mounted mirror of %q at %q", cfg.RoStoragePath, mirror)
+	originalPath := cfg.RoStoragePath
+	cfg.RoStoragePath = mirror
 
 	sublog.Info("Setting up scratch Store")
 	scratchRun, cleanupScratch := common.MustTempDir("scratch-runroot-*")
 	scratchStore, err := storage.GetStore(storage.StoreOptions{
-		GraphRoot:       mirror,
+		GraphRoot:       cfg.RoStoragePath,
 		RunRoot:         scratchRun,
 		GraphDriverName: "overlay",
 	})
@@ -232,6 +234,7 @@ func setupScratchStore(cfg common.Config) (storage.Store, func(), error) {
 		return nil, nil, err
 	}
 	cleanup := func() {
+		cfg.RoStoragePath = originalPath
 		scratchStore.Shutdown(false)
 		cleanupScratch()
 		mirrorCleanup()

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+)
+
+// Mirror creates a writable mirror of srcDir in a temp directory.
+// It returns the mirror path, a cleanup func (which pushes changes back to srcDir),
+// and any error from setup.
+//
+// Note: this requires the "rsync" binary to be installed and in PATH.
+func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
+    mp, err := os.MkdirTemp("", "rsync-mirror-")
+    if err != nil {
+        return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+    }
+
+    // Ensure the srcDir path ends with a trailing slash for rsync behavior
+    srcPath := filepath.Clean(srcDir) + string(os.PathSeparator)
+    mirrorPath := filepath.Clean(mp) + string(os.PathSeparator)
+
+    cmd := exec.Command("rsync", "-a", srcPath, mirrorPath)
+    if out, err2 := cmd.CombinedOutput(); err2 != nil {
+        os.RemoveAll(mp)
+        return "", nil, fmt.Errorf("initial rsync failed: %v\n%s", err2, out)
+    }
+
+    cleanup = func() error {
+        cmdBack := exec.Command("rsync", "-a", "--delete", mirrorPath, srcPath)
+        if out, err2 := cmdBack.CombinedOutput(); err2 != nil {
+            return fmt.Errorf("rsync back failed: %v\n%s", err2, out)
+        }
+
+        if err2 := os.RemoveAll(mp); err2 != nil {
+            return fmt.Errorf("failed to remove temp dir %q: %w", mp, err2)
+        }
+        return nil
+    }
+
+    return mp, cleanup, nil
+}
+


### PR DESCRIPTION
Mirror creates a writable mirror of srcDir in a temp directory.
It returns the mirror path, a cleanup func (which pushes changes back to srcDir), and any error from setup