### PR TITLE
Custom command line help message flag format

### DIFF
--- a/common/cli.go
+++ b/common/cli.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"stings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -12,24 +13,68 @@ import (
 const Version = "1.0.0"
 
 func usage_banner() {
-	fmt.Fprintf(flag.CommandLine.Output(), `
+    out := flag.CommandLine.Output()
+
+	// Header
+    fmt.Fprintf(out, `
 Parallax
 OCI image migration tool for Podman on HPC systems
 
 Usage:
-  parallax -migrate -image <image[:tag]> [options]
-  parallax -rmi -image <image[:tag]> [options]
+  parallax --migrate --image <image[:tag]> [options]
+  parallax --rmi     --image <image[:tag]> [options]
 
 Options:
 `)
-	flag.PrintDefaults()
-	fmt.Fprintf(flag.CommandLine.Output(), `
+
+    // New flag section
+	order := []string{
+        "migrate",
+        "rmi",
+        "image",
+        "podmanRoot",
+        "roStoragePath",
+        "mksquashfsPath",
+        "log-level",
+        "version",
+    }
+    for _, name := range order {
+        if f := flag.CommandLine.Lookup(name); f != nil {
+            printFlag(out, f)
+        }
+    }
+
+	// Footer
+    fmt.Fprintf(out, `
 Examples:
-  parallax -migrate -image ubuntu:latest
-  parallax -rmi -image alpine:3.18
+  parallax --migrate --image ubuntu:latest
+  parallax --rmi     --image alpine:3.18
 
 `)
 }
+
+func printFlag(out *os.File, f *flag.Flag) {
+    // double-dashed name!
+    line := fmt.Sprintf("  --%s", f.Name)
+
+    // alignment
+	if len(f.Name) < 8 {
+        line += "\t"
+    } else {
+        line += "\t"
+    }
+
+    // usage text
+    line += f.Usage
+
+    // show default
+    if def := f.DefValue; def != "" && def != "false" {
+        line += fmt.Sprintf(" (default %q)", def)
+    }
+	// and print
+    fmt.Fprintln(out, line)
+}
+
 
 // Track we are being asked
 type Operation int
@@ -108,3 +153,4 @@ func ParseAndValidateFlags(fs *flag.FlagSet, args []string) (*CLI, error) {
 		LogLevel: level,
 	}, nil
 }
+

--- a/common/cli.go
+++ b/common/cli.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"stings"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )

--- a/common/cli.go
+++ b/common/cli.go
@@ -53,7 +53,7 @@ Examples:
 `)
 }
 
-func printFlag(out *io.Writer, f *flag.Flag) {
+func printFlag(out io.Writer, f *flag.Flag) {
     // double-dashed name!
     line := fmt.Sprintf("  --%s", f.Name)
 

--- a/common/cli.go
+++ b/common/cli.go
@@ -3,8 +3,8 @@ package common
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -53,7 +53,7 @@ Examples:
 `)
 }
 
-func printFlag(out *os.File, f *flag.Flag) {
+func printFlag(out *io.Writer, f *flag.Flag) {
     // double-dashed name!
     line := fmt.Sprintf("  --%s", f.Name)
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	cli, err := common.ParseAndValidateFlags(flag.CommandLine, os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		flag.commandline.Usage()
+		flag.CommandLine.Usage()
 		os.Exit(2)
 	}
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	cli, err := common.ParseAndValidateFlags(flag.CommandLine, os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		common.usage_banner()
+		flag.commandline.Usage()
 		os.Exit(2)
 	}
 

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 	cli, err := common.ParseAndValidateFlags(flag.CommandLine, os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		flag.Usage()
+		common.usage_banner()
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
CLI now suggest use of double dash long options as per other linux tools. 
Custom code to work around default single dash reporting by Go flags.