### PR TITLE
Efficient mirror

### DIFF
--- a/cmd/migration.go
+++ b/cmd/migration.go
@@ -331,9 +331,6 @@ func createSquashSidecarFromMount(srcDir, link string, cfg common.Config) error 
 
 	squashPath := filepath.Join(cfg.RoStoragePath, "squash", link+".squash")
 	if _, err := os.Stat(squashPath); errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(filepath.Dir(squashPath), 0o755); err != nil {
-			return err
-		}
 
 		// Choose default or user provided flags
 		defaultFlags := []string {

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -22,10 +22,10 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         return "", nil, fmt.Errorf("Failed to create temp dir: %w", err)
     }
 
-   log.Infof("Mirror: rsync from %s to %s (no squash/)", srcPath, mirrorPath)
 
     srcPath := filepath.Clean(srcDir) + string(os.PathSeparator)
     mirrorPath := filepath.Clean(mp) + string(os.PathSeparator)
+    log.Infof("Mirror: rsync from %s to %s (no squash/)", srcPath, mirrorPath)
 
     // Setup mirror but skip squash/ dir
     cmd := exec.Command("rsync",
@@ -38,13 +38,13 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         return "", nil, fmt.Errorf("Initial rsync failed: %v\n%s", err2, out)
     }
 
-    log.Infof("Mirror: creating squash symlink %s to %s", linkName, realSquash)
     // In case srcDir is not init, we might not have a squash dir, lets create it
     realSquash := filepath.Join(srcDir, "squash")
+    linkName   := filepath.Join(mirrorPath, "squash")
+    log.Infof("Mirror: creating squash symlink %s to %s", linkName, realSquash)
     if err := os.MkdirAll(realSquash, 0o755); err != nil {
         return "", nil, fmt.Errorf("Failed to create real squash dir %q: %w", realSquash, err)
     }
-    linkName   := filepath.Join(mirrorPath, "squash")
     if err2 := os.Symlink(realSquash, linkName); err2 != nil {
         os.RemoveAll(mp)
         return "", nil, fmt.Errorf("Squash symlink failed: %w", err2)

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -33,8 +33,13 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         return "", nil, fmt.Errorf("initial rsync failed: %v\n%s", err2, out)
     }
 
-    // Now we symlink real squash into mirror
+    // In case srcDir is not init, we might not have a squash dir, lets create it
     realSquash := filepath.Join(srcDir, "squash")
+    if err := os.MkdirAll(realSquash, 0o755); err != nil {
+        return fmt.Errorf("failed to create real squash dir %q: %w", realSquash, err)
+    }
+
+    // Now we symlink real squash into mirror
     linkName   := filepath.Join(mirrorPath, "squash")
     if err2 := os.Symlink(realSquash, linkName); err2 != nil {
         os.RemoveAll(mp)

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -5,6 +5,8 @@ import (
     "os"
     "os/exec"
     "path/filepath"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // Mirror creates a writable mirror of srcDir in a temp directory.
@@ -13,12 +15,15 @@ import (
 //
 // Note: this requires the "rsync" binary to be installed and in PATH.
 func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
+	log.Infof("Mirror: creating temp dir for %q", srcDir)
+
     mp, err := os.MkdirTemp("", "rsync-mirror-")
     if err != nil {
         return "", nil, fmt.Errorf("Failed to create temp dir: %w", err)
     }
 
-    // Ensure the srcDir path ends with a trailing slash for rsync behavior
+   log.Infof("Mirror: rsync from %s to %s (no squash/)", srcPath, mirrorPath)
+
     srcPath := filepath.Clean(srcDir) + string(os.PathSeparator)
     mirrorPath := filepath.Clean(mp) + string(os.PathSeparator)
 
@@ -33,13 +38,12 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         return "", nil, fmt.Errorf("Initial rsync failed: %v\n%s", err2, out)
     }
 
+    log.Infof("Mirror: creating squash symlink %s to %s", linkName, realSquash)
     // In case srcDir is not init, we might not have a squash dir, lets create it
     realSquash := filepath.Join(srcDir, "squash")
     if err := os.MkdirAll(realSquash, 0o755); err != nil {
         return "", nil, fmt.Errorf("Failed to create real squash dir %q: %w", realSquash, err)
     }
-
-    // Now we symlink real squash into mirror
     linkName   := filepath.Join(mirrorPath, "squash")
     if err2 := os.Symlink(realSquash, linkName); err2 != nil {
         os.RemoveAll(mp)
@@ -48,10 +52,12 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
 
     // On cleanup we remove link then rsync back
     cleanup = func() error {
+        log.Infof("Mirror-cleanup: remove mirror’s squash symlink")
         if err := os.Remove(filepath.Join(mirrorPath, "squash")); err != nil {
             return fmt.Errorf("Failed to remove squash symlink: %w", err)
         }
 
+        log.Infof("Mirror-cleanup: rsync back from %s to %s (excluding squash/)", mirrorPath, srcPath)
         cmdBack := exec.Command("rsync",
             "-a",
             "--exclude=squash/",

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -49,7 +49,7 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
 
         cmdBack := exec.Command("rsync",
             "-a",
-            "--exclude squash/"
+            "--exclude squash/",
             "--delete",
             mirrorPath, srcPath,
         )

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -54,7 +54,7 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
 
         cmdBack := exec.Command("rsync",
             "-a",
-            "--exclude squash/",
+            "--exclude=squash/",
             "--delete",
             mirrorPath, srcPath,
         )

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -15,7 +15,7 @@ import (
 func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
     mp, err := os.MkdirTemp("", "rsync-mirror-")
     if err != nil {
-        return "", nil, fmt.Errorf("failed to create temp dir: %w", err)
+        return "", nil, fmt.Errorf("Failed to create temp dir: %w", err)
     }
 
     // Ensure the srcDir path ends with a trailing slash for rsync behavior
@@ -30,20 +30,20 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
     )
     if out, err2 := cmd.CombinedOutput(); err2 != nil {
         os.RemoveAll(mp)
-        return "", nil, fmt.Errorf("initial rsync failed: %v\n%s", err2, out)
+        return "", nil, fmt.Errorf("Initial rsync failed: %v\n%s", err2, out)
     }
 
     // In case srcDir is not init, we might not have a squash dir, lets create it
     realSquash := filepath.Join(srcDir, "squash")
     if err := os.MkdirAll(realSquash, 0o755); err != nil {
-        return fmt.Errorf("failed to create real squash dir %q: %w", realSquash, err)
+        return "", nil, fmt.Errorf("Failed to create real squash dir %q: %w", realSquash, err)
     }
 
     // Now we symlink real squash into mirror
     linkName   := filepath.Join(mirrorPath, "squash")
     if err2 := os.Symlink(realSquash, linkName); err2 != nil {
         os.RemoveAll(mp)
-        return "", nil, fmt.Errorf("squash symlink failed: %w", err2)
+        return "", nil, fmt.Errorf("Squash symlink failed: %w", err2)
     }
 
     // On cleanup we remove link then rsync back


### PR DESCRIPTION
Now mirror copies store "metadata" using rsync, skips the squash directory which we symlink, this way we avoid heavy data transfers as all image data is kept in the squashfs files. The final step syncs back the metadata to the original store after migration or rmi.