### PR TITLE
Fc strict input validation

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -39,7 +39,7 @@ func IsExecutable(path string) error {
 	return nil
 }
 
-func validateRoStorePath(path string) error {
+func validateRoStore(path string) error {
 	fileInfo, err := os.Stat(path)
 	if err != nil || !fileInfo.IsDir() {
 		return fmt.Errorf("'%s' is not a valid directory", path)

--- a/common/config.go
+++ b/common/config.go
@@ -39,7 +39,7 @@ func IsExecutable(path string) error {
 	return nil
 }
 
-func validateRoStore(path string) error {
+func ValidateRoStore(path string) error {
 	fileInfo, err := os.Stat(path)
 	if err != nil || !fileInfo.IsDir() {
 		return fmt.Errorf("'%s' is not a valid directory", path)

--- a/common/config.go
+++ b/common/config.go
@@ -3,6 +3,7 @@ package common
 import (
 	"os"
 	"fmt"
+	"path/filepath"
 )
 
 type Config struct {
@@ -35,6 +36,33 @@ func IsExecutable(path string) error {
 	if info.Mode()&0111 == 0 {
 		return fmt.Errorf("%s is not executable", path)
 	}
+	return nil
+}
+
+func validateRoStorePath(path string) error {
+	fileInfo, err := os.Stat(path)
+	if err != nil || !fileInfo.IsDir() {
+		return fmt.Errorf("'%s' is not a valid directory", path)
+	}
+
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("failed reading directory '%s': %w", path, err)
+	}
+	// Quick accept if directory is empty
+	if len(files) == 0 {
+		return nil
+	}
+
+	// Validate that at least Podman-overlay Store subdirectories are present
+	requiredSubdirs := []string{"overlay", "overlay-images", "overlay-layers"}
+	for _, dir := range requiredSubdirs {
+		fullPath := filepath.Join(path, dir)
+		if err := IsDir(fullPath); err != nil {
+			return fmt.Errorf("storage validation failed: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	switch cli.Op {
 		case common.OpMigrate:
-			if err := common.validateRoStore(cli.Config.RoStoragePath); err != nil {
+			if err := common.ValidateRoStore(cli.Config.RoStoragePath); err != nil {
 				logrus.Fatalf("Storage validation failed before migration: %v", err)
 			}
 			_, err := cmd.RunMigration(cli.Config)
@@ -46,7 +46,7 @@ func main() {
 				logrus.Fatalf("Migration failed for image '%s': %v", cli.Config.Image, err)
 			}
 		case common.OpRmi:
-			if err := common.validateRoStore(cli.Config.RoStoragePath); err != nil {
+			if err := common.ValidateRoStore(cli.Config.RoStoragePath); err != nil {
 				logrus.Fatalf("Storage validation failed before rmi: %v", err)
 			}
 			err = cmd.RunRmi(cli.Config)

--- a/main.go
+++ b/main.go
@@ -38,12 +38,17 @@ func main() {
 
 	switch cli.Op {
 		case common.OpMigrate:
-			// TODO: we are not using migration return anymore, maybe drop it
+			if err := common.validateRoStore(cli.Config.RoStoragePath); err != nil {
+				logrus.Fatalf("Storage validation failed before migration: %v", err)
+			}
 			_, err := cmd.RunMigration(cli.Config)
 			if err != nil {
 				logrus.Fatalf("Migration failed for image '%s': %v", cli.Config.Image, err)
 			}
 		case common.OpRmi:
+			if err := common.validateRoStore(cli.Config.RoStoragePath); err != nil {
+				logrus.Fatalf("Storage validation failed before rmi: %v", err)
+			}
 			err = cmd.RunRmi(cli.Config)
 			if err != nil {
 				logrus.Fatalf("RMI operation failed for image '%s': %v", cli.Config.Image, err)

--- a/tests/parallax-cli-checks.bats
+++ b/tests/parallax-cli-checks.bats
@@ -45,3 +45,21 @@ load helpers.bash
 	[[ "$output" =~ "flag provided but not defined" ]]
 }
 
+@test "Fails migration when --roStoragePath directory is non-empty" {
+  # Populate the storage dir with a dummy file
+  # This way the directory is neither empty or with a store structure
+  touch "$RO_STORAGE/dummy-file"
+
+  run "$PARALLAX_BINARY" \
+    --podmanRoot    "$PODMAN_ROOT" \
+    --roStoragePath "$RO_STORAGE" \
+    --mksquashfsPath "$MKSQUASHFS_PATH" \
+    --log-level     info \
+    --migrate \
+    --image         ubuntu:latest
+
+  # Expect a non-zero exit code and a validation error
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Storage validation failed" ]]
+}
+

--- a/tests/parallax-cli-checks.bats
+++ b/tests/parallax-cli-checks.bats
@@ -73,8 +73,8 @@ load helpers.bash
     --roStoragePath "$RO_STORAGE" \
     --mksquashfsPath "$MKSQUASHFS_PATH" \
     --log-level info \
-    --migrate \
-    --rmi ubuntu:latest
+    --rmi \
+    --image ubuntu:latest
 
   # Expect a non-zero exit code and a validation error
   [ "$status" -ne 0 ]

--- a/tests/parallax-cli-checks.bats
+++ b/tests/parallax-cli-checks.bats
@@ -1,48 +1,48 @@
 load helpers.bash
 
 @test "Either -migrate or -rmi is specified" {
-	run \
-		"$PARALLAX_BINARY"
-	[ "$status" -ne 0 ]
-	[[ "$output" =~ "Must specify either -migrate or -rmi" ]]
+  run \
+    "$PARALLAX_BINARY"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Must specify either -migrate or -rmi" ]]
 }
 
 @test "Fails if both -migrate and -rmi are passed" {
-	run \
-		"$PARALLAX_BINARY" -migrate -rmi -image ubuntu:latest
-	[ "$status" -ne 0 ]
-	[[ "$output" =~ "Must specify either -migrate or -rmi" ]]
+  run \
+    "$PARALLAX_BINARY" -migrate -rmi -image ubuntu:latest
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Must specify either -migrate or -rmi" ]]
 }
 
 @test "Fails if --image is missing" {
-	run \
-		"$PARALLAX_BINARY" -migrate
-	[ "$status" -ne 0 ]
-	[[ "$output" =~ "Must specify -image" ]]
+  run \
+    "$PARALLAX_BINARY" -migrate
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Must specify -image" ]]
 }
 
 @test "Checks version" {
-	run \
-		"$PARALLAX_BINARY" -version
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Parallax version" ]]
+  run \
+    "$PARALLAX_BINARY" -version
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Parallax version" ]]
 }
 
 @test "Usage is printed" {
-	run \
-	   "$PARALLAX_BINARY" -help
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "OCI image migration tool" ]]
-	[[ "$output" =~ "Usage" ]]
-	[[ "$output" =~ "-migrate" ]]
-	[[ "$output" =~ "-image" ]]
+  run \
+    "$PARALLAX_BINARY" -help
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "OCI image migration tool" ]]
+  [[ "$output" =~ "Usage" ]]
+  [[ "$output" =~ "-migrate" ]]
+  [[ "$output" =~ "-image" ]]
 }
 
 @test "Checks unknown flag message" {
-	run \
-		"$PARALLAX_BINARY" -unknownflag
-	[ "$status" -ne 0 ]
-	[[ "$output" =~ "flag provided but not defined" ]]
+  run \
+    "$PARALLAX_BINARY" -unknownflag
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "flag provided but not defined" ]]
 }
 
 @test "Fails migration when --roStoragePath directory is non-empty" {
@@ -51,12 +51,30 @@ load helpers.bash
   touch "$RO_STORAGE/dummy-file"
 
   run "$PARALLAX_BINARY" \
-    --podmanRoot    "$PODMAN_ROOT" \
+    --podmanRoot "$PODMAN_ROOT" \
     --roStoragePath "$RO_STORAGE" \
     --mksquashfsPath "$MKSQUASHFS_PATH" \
-    --log-level     info \
+    --log-level info \
     --migrate \
-    --image         ubuntu:latest
+    --image ubuntu:latest
+
+  # Expect a non-zero exit code and a validation error
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "Storage validation failed" ]]
+}
+
+@test "Fails RMI when --roStoragePath directory is non-empty" {
+  # Populate the storage dir with a dummy file
+  # This way the directory is neither empty or with a store structure
+  touch "$RO_STORAGE/dummy-file"
+
+  run "$PARALLAX_BINARY" \
+    --podmanRoot "$PODMAN_ROOT" \
+    --roStoragePath "$RO_STORAGE" \
+    --mksquashfsPath "$MKSQUASHFS_PATH" \
+    --log-level info \
+    --migrate \
+    --rmi ubuntu:latest
 
   # Expect a non-zero exit code and a validation error
   [ "$status" -ne 0 ]

--- a/tests/parallax-cli-checks.bats
+++ b/tests/parallax-cli-checks.bats
@@ -87,14 +87,20 @@ load helpers.bash
     pull alpine:latest
   [ "$status" -eq 0 ]
 
-  # Now migration should pass
+  run "$PODMAN_BINARY" \
+    --root "$PODMAN_ROOT" \
+    --runroot "$PODMAN_RUNROOT" \
+    pull ubuntu:latest
+  [ "$status" -eq 0 ]
+
+  # Now migration should pass check, and also complete a ubuntu migration
   run "$PARALLAX_BINARY" \
     --podmanRoot "$PODMAN_ROOT" \
     --roStoragePath "$RO_STORAGE" \
     --mksquashfsPath "$MKSQUASHFS_PATH" \
     --log-level info \
     --migrate \
-    --image alpine:latest
+    --image ubuntu:latest
 
   [ "$status" -eq 0 ]
   [[ "$output" =~ "Migration successfully completed" ]]


### PR DESCRIPTION
Ro Storage is now validated to be either an empty dir or to have the overlay directories of a podman initialized store.
This would make more difficult, options mistakes that trigger large mirror operations.