### PR TITLE
Fc robust mirror

### DIFF
--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -29,10 +29,10 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
 
     // Define PodmanOverlay file and directory patterns for mirror
     allowedPatterns := []string{
-        "overlay/",
-        "overlay-containers/",
-        "overlay-images/",
-        "overlay-layers/",
+        "overlay/***",
+        "overlay-containers/***",
+        "overlay-images/***",
+        "overlay-layers/***",
         "storage.lock",
         "userns.lock",
     }

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -47,6 +47,7 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
 
     log.Infof("Mirror setup: rsync from %s to %s", srcPath, mirrorPath)
     rsyncCmd := append(rsyncArgs, srcPath, mirrorPath)
+    log.Infof("  rsync args %v", rsyncCmd)
     cmd := exec.Command("rsync", rsyncCmd...)
 
     if out, err2 := cmd.CombinedOutput(); err2 != nil {

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -42,12 +42,12 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         includePatterns = append(includePatterns, fmt.Sprintf("--include=%s", pattern))
     }
 
-	rsyncArgs := append([]string{"rsync"}, includePatterns...)
-    rsyncArgs = append(rsyncArgs, "-a", "--exclude=*", "--delete")
+	rsyncArgs := append([]string{"--exclude=*"}, includePatterns...)
+    rsyncArgs = append(rsyncArgs, "-a", "--delete")
 
     log.Infof("Mirror setup: rsync from %s to %s", srcPath, mirrorPath)
     rsyncCmd := append(rsyncArgs, srcPath, mirrorPath)
-    cmd := exec.Command(rsyncCmd...)
+    cmd := exec.Command("rsync", rsyncCmd...)
 
     if out, err2 := cmd.CombinedOutput(); err2 != nil {
         os.RemoveAll(mp)
@@ -75,7 +75,7 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
 
         log.Infof("Mirror-cleanup: rsync back from %s to %s", mirrorPath, srcPath)
         rsyncCmd = append(rsyncArgs, mirrorPath, srcPath)
-        cmdBack := exec.Command(rsyncCmd...)
+        cmdBack := exec.Command("rsync", rsyncCmd...)
 
         if out, err2 := cmdBack.CombinedOutput(); err2 != nil {
             return fmt.Errorf("rsync back failed: %v\n%s", err2, out)

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -42,8 +42,8 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         includePatterns = append(includePatterns, fmt.Sprintf("--include=%s", pattern))
     }
 
-	rsyncArgs := append([]string{"--exclude=*"}, includePatterns...)
-    rsyncArgs = append(rsyncArgs, "-a", "--delete")
+	rsyncArgs := append([]string{"-a"}, includePatterns...)
+    rsyncArgs = append(rsyncArgs, "--exclude=*", "--delete")
 
     log.Infof("Mirror setup: rsync from %s to %s", srcPath, mirrorPath)
     rsyncCmd := append(rsyncArgs, srcPath, mirrorPath)

--- a/common/rsync-mirror.go
+++ b/common/rsync-mirror.go
@@ -42,7 +42,7 @@ func Mirror(srcDir string) (mirrorDir string, cleanup func() error, err error) {
         includePatterns = append(includePatterns, fmt.Sprintf("--include=%s", pattern))
     }
 
-    rsyncArgs = append([]string{"rsync"}, includePatterns...)
+	rsyncArgs := append([]string{"rsync"}, includePatterns...)
     rsyncArgs = append(rsyncArgs, "-a", "--exclude=*", "--delete")
 
     log.Infof("Mirror setup: rsync from %s to %s", srcPath, mirrorPath)


### PR DESCRIPTION
Reduced scope of the rsync to sync specific folders using strict include pattern plus an exclude all else. This should prevent unintentional mistakes.
Moreover, functionality on repo bootstrap and on a working populated repo (tests/multi-command-test.bats)